### PR TITLE
Fix evaluator bugs, add grammar shorthands, bump to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,11 @@
 * V1.0.0 - Initial Release
 * V1.0.1 - Added readme to package
+* V1.3.0 - Event-driven detailed evaluation (`ParseRollDetailed`, `DiceEvaluationResult`, `DieEvent`); backward-compatible `ParseRoll`.
+* V1.4.1 - Arithmetic roll expressions (`3d20+5d6-1d4+1`) with per-term grouping metadata (`DieEvent.GroupId`, `DieEvent.GroupOperator`); keep/drop refactor and reference-equality fix.
+* V1.5.0 - Bug fixes and grammar shorthands:
+  * **Fixed**: `Evaluate()`/`ParseRoll` rerolled dice using the previous roll's *result* as the die's side count (e.g. `4d6ro=1` rerolled a 1 on a 1-sided die). Rerolls now use the original die.
+  * **Fixed**: combining success and failure counting (e.g. `6d10>8f<2`) now returns successes minus failures counted against the same dice; previously the two modifiers clobbered each other in both evaluation paths. When a die matches both criteria, success takes precedence.
+  * **Changed**: `Evaluate()` is now a projection of `EvaluateDetailed()` — one implementation, one set of semantics. As a result, keep/drop written *before* explode/reroll/compound now behaves per the documented phase model (generation, then keep/drop, then finalization), matching `ParseRollDetailed` and common VTT behavior. Expressions that relied on the old order-sensitive simple path (e.g. `2d20kh1!=20` exploding only the kept die) will see different results.
+  * **Added**: grammar shorthands — bare `!` and `^` explode/compound on the die's maximum face; `!!` is an alias for `^`; a bare integer after `ro`, `rc`, `!`, or `^` means equality (`ro1` == `ro=1`, `3d6!6` == `3d6!=6`).
+  * **Added**: `DiceEvaluator.MaxRerolls` property (default 10), matching the existing `MaxExplosions`/`MaxCompounds` loop guards.
+  * **Improved**: `FormatException` from `ParseRoll`/`ParseRollDetailed` now includes the parser diagnostic (position and expected tokens).

--- a/DotDice/DotDice.csproj
+++ b/DotDice/DotDice.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>DotDice</PackageId>
-    <Version>1.3.0</Version>
+    <Version>1.5.0</Version>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/DotDice/README.md
+++ b/DotDice/README.md
@@ -89,8 +89,11 @@ Console.WriteLine("Individual Events:");
 foreach (var evt in detailedResult.Events)
 {
     Console.WriteLine($"  Die: {evt.DieType}, Value: {evt.Value}, Status: {evt.Status}");
-    // evt.Type shows if it was Initial, Reroll, Explode, etc.
-    // evt.Significance shows if it was a critical hit, minimum roll, etc.
+    // evt.Type is the DieEventType: Initial, Reroll, Explosion, or Compound.
+    // Note: rerolled and exploded dice keep their original DieType (e.g. Basic);
+    // use evt.Type, not evt.DieType, to tell how an event was generated.
+    // evt.Significance shows if it was a maximum or minimum roll.
+    // evt.Status shows if the die was Kept, Dropped (keep/drop), or Discarded (reroll/compound).
 }
 ```
 
@@ -156,6 +159,20 @@ int wodSuccesses = evaluator.Evaluate(wodRoll);
 Console.WriteLine($"World of Darkness: {wodSuccesses} successes");
 ```
 
+### Evaluator Settings
+
+Rerolls, explosions, and compounds are capped to prevent infinite loops. The caps are configurable per evaluator (each must be at least 1):
+
+```csharp
+var evaluator = new DiceEvaluator();
+evaluator.MaxExplosions = 50;  // default 100, per die
+evaluator.MaxCompounds = 50;   // default 100, per die
+evaluator.MaxRerolls = 5;      // default 10, per die (rc only; ro always rerolls once)
+
+// A seed can be supplied for reproducible rolls
+var seeded = new DiceEvaluator(42);
+```
+
 ### Advanced Multi-Roll Scenarios
 
 More complex game systems may require multiple rolls that interact with each other. You can use the results of multiple evaluations:
@@ -189,23 +206,25 @@ DotDice supports a comprehensive dice notation syntax:
 - Complex expressions: `3d20+5d6-1d4+1`
 
 ### Modifiers
-- `kh#` - Keep highest # dice
-- `kl#` - Keep lowest # dice
-- `dh#` - Drop highest # dice
-- `dl#` - Drop lowest # dice
-- `r<#`, `r>#`, `r=#` - Reroll once if less than, greater than, or equal to #
-- `rr<#`, `rr>#`, `rr=#` - Reroll multiple times until condition is no longer met
-- `!=#`, `!>#`, `!<#` - Explode if condition is met
-- `^=#`, `^>#`, `^<#` - Compound if condition is met
+- `kh#` / `kh` - Keep highest # dice (defaults to 1)
+- `kl#` / `kl` - Keep lowest # dice (defaults to 1)
+- `dh#` / `dh` - Drop highest # dice (defaults to 1)
+- `dl#` / `dl` - Drop lowest # dice (defaults to 1)
+- `ro<#`, `ro>#`, `ro=#`, `ro#` - Reroll once if less than, greater than, or equal to # (`ro#` is shorthand for `ro=#`)
+- `rc<#`, `rc>#`, `rc=#`, `rc#` - Reroll repeatedly until the condition is no longer met (capped by `MaxRerolls`, default 10)
+- `!=#`, `!>#`, `!<#`, `!#`, `!` - Explode if condition is met; bare `!` explodes on the die's maximum face
+- `^=#`, `^>#`, `^<#`, `^#`, `^` (alias `!!`) - Compound if condition is met; bare `^`/`!!` compounds on the maximum face
 - `+#`, `-#` - Add or subtract a constant value
-- `cs>#`, `cs<#`, `cs=#` - Count successes (greater than, less than, or equal to #)
-- `cf>#`, `cf<#`, `cf=#` - Count failures (greater than, less than, or equal to #)
+- `>#`, `<#`, `=#` - Count successes (greater than, less than, or equal to #)
+- `f>#`, `f<#`, `f=#` - Count failures; combined with a success modifier the result is successes minus failures
 
 ### Examples
 - `4d6kh3` - Roll 4d6, keep highest 3 (D&D ability scores)
 - `2d20kh1` - Roll 2d20, keep highest (D&D advantage)
-- `1d6!=6` - Roll 1d6, explode on 6 (Savage Worlds)
+- `1d6!` - Roll 1d6, explode on 6 (Savage Worlds)
+- `4d6ro1` - Roll 4d6, reroll 1s once
 - `5d6>4` - Roll 5d6, count successes of 5+ (Shadowrun)
+- `6d10>8f<2` - Roll 6d10, successes on 9+ minus botches on 1s (World of Darkness)
 - `3d6+2d4-1` - Roll 3d6 plus 2d4 minus 1
 
 ## Contributing

--- a/DotDice/src/Evaluator/DiceEvaluator.cs
+++ b/DotDice/src/Evaluator/DiceEvaluator.cs
@@ -6,11 +6,16 @@ namespace DotDice.Evaluator
 {
     /// <summary>
     /// Evaluates a roll and returns the result.
+    ///
+    /// Evaluation follows a three-phase model:
+    ///   Phase 1 (Generation): rerolls, explosions, and compounds create new die events.
+    ///   Phase 2 (Modification): keep/drop modifiers mark events as dropped.
+    ///   Phase 3 (Finalization): success/failure counting and constant modifiers are applied.
+    /// Phases run in this order regardless of the order modifiers appear in the expression.
     /// </summary>
     public class DiceEvaluator
     {
         private readonly IRandomNumberGenerator<int> _rng;
-        private record rollResult(int result, DieType type);
         // Safety limits to prevent infinite loops
         // Must be greater than 0 to allow at least one explosion or compound
         private int _maxExplosions = 100;
@@ -41,6 +46,20 @@ namespace DotDice.Evaluator
             }
         }
 
+        private int _maxRerolls = 10;
+        public int MaxRerolls
+        {
+            get { return _maxRerolls; }
+            set
+            {
+                if (value < 1)
+                {
+                    throw new ArgumentOutOfRangeException("MaxRerolls must be greater than 0");
+                }
+                _maxRerolls = value;
+            }
+        }
+
         public DiceEvaluator(int? seed = null)
         {
             // Initialize with provided seed or a default time-dependent seed
@@ -52,19 +71,14 @@ namespace DotDice.Evaluator
             _rng = rng;
         }
 
+        /// <summary>
+        /// Evaluates a roll and returns its final value.
+        /// This is a projection of <see cref="EvaluateDetailed"/> so both APIs
+        /// are guaranteed to share one implementation and one set of semantics.
+        /// </summary>
         public int Evaluate(Roll roll)
         {
-            switch (roll)
-            {
-                case BasicRoll basicRoll:
-                    return EvaluateBasicRoll(basicRoll);
-                case Constant constant:
-                    return constant.Value;
-                case ArithmeticRoll arithmeticRoll:
-                    return EvaluateArithmeticRoll(arithmeticRoll);
-                default:
-                    throw new ArgumentException("Unknown roll type", nameof(roll));
-            }
+            return EvaluateDetailed(roll).Value;
         }
 
         public DiceEvaluationResult EvaluateDetailed(Roll roll)
@@ -81,7 +95,7 @@ namespace DotDice.Evaluator
                     throw new ArgumentException("Unknown roll type", nameof(roll));
             }
         }
-        
+
         private DiceEvaluationResult EvaluateBasicRollDetailed(BasicRoll basicRoll, int? groupId = null, ArithmeticOperator? groupOperator = null)
         {
             // Generation Phase: Create initial events
@@ -100,47 +114,9 @@ namespace DotDice.Evaluator
             return new DiceEvaluationResult(finalValue, events);
         }
 
-        private int EvaluateBasicRoll(BasicRoll basicRoll)
-        {
-            // Generate random numbers for each die
-            var rolls = Enumerable.Range(0, basicRoll.NumberOfDice)
-                .Select(_ => RollDie(basicRoll.DieType))
-                .ToList();
-
-            // Apply modifiers
-            rolls = ApplyModifiers(rolls, basicRoll.Modifiers);
-
-            // Return the sum of the rolls
-            return rolls.Sum(r => r.result);
-        }
-
         private DiceEvaluationResult EvaluateBasicRollDetailed(BasicRoll basicRoll)
         {
             return EvaluateBasicRollDetailed(basicRoll, null, null);
-        }
-
-        private int EvaluateArithmeticRoll(ArithmeticRoll arithmeticRoll)
-        {
-            int result = 0;
-            
-            foreach (var (operation, roll) in arithmeticRoll.Terms)
-            {
-                int rollValue = Evaluate(roll);
-                
-                switch (operation)
-                {
-                    case ArithmeticOperator.Add:
-                        result += rollValue;
-                        break;
-                    case ArithmeticOperator.Subtract:
-                        result -= rollValue;
-                        break;
-                    default:
-                        throw new ArgumentException($"Unknown arithmetic operator: {operation}");
-                }
-            }
-            
-            return result;
         }
 
         private DiceEvaluationResult EvaluateArithmeticRollDetailed(ArithmeticRoll arithmeticRoll)
@@ -148,11 +124,11 @@ namespace DotDice.Evaluator
             int result = 0;
             var allEvents = new List<DieEvent>();
             int groupId = 0; // Assign unique group IDs
-            
+
             foreach (var (operation, roll) in arithmeticRoll.Terms)
             {
                 DiceEvaluationResult rollResult;
-                
+
                 // Evaluate the roll with group information
                 if (roll is BasicRoll basicRoll)
                 {
@@ -162,7 +138,7 @@ namespace DotDice.Evaluator
                 {
                     rollResult = EvaluateDetailed(roll);
                 }
-                
+
                 switch (operation)
                 {
                     case ArithmeticOperator.Add:
@@ -202,28 +178,16 @@ namespace DotDice.Evaluator
                     default:
                         throw new ArgumentException($"Unknown arithmetic operator: {operation}");
                 }
-                
+
                 // For non-BasicRoll events (like constants from other sources), assign group info if missing
-                var eventsToAdd = rollResult.Events.Select(e => 
+                var eventsToAdd = rollResult.Events.Select(e =>
                     e.GroupId.HasValue ? e : e with { GroupId = groupId, GroupOperator = operation }).ToList();
-                
+
                 allEvents.AddRange(eventsToAdd);
                 groupId++; // Increment group ID for next term
             }
-            
-            return new DiceEvaluationResult(result, allEvents);
-        }
 
-        private rollResult RollDie(DieType dieType)
-        {
-            return dieType switch
-            {
-                DieType.Basic roll => new(_rng.Next(1, roll.sides + 1), dieType),
-                DieType.Reroll roll => new(_rng.Next(1, roll.sides + 1), dieType),
-                DieType.Percent => new(_rng.Next(1, 101), dieType),
-                DieType.Fudge => new(_rng.Next(-1, 2), dieType),
-                _ => throw new ArgumentException("Unknown die type", nameof(dieType))
-            };
+            return new DiceEvaluationResult(result, allEvents);
         }
 
         private DieEvent RollDieEvent(DieType dieType, DieEventType eventType, int? groupId = null, ArithmeticOperator? groupOperator = null)
@@ -252,7 +216,7 @@ namespace DotDice.Evaluator
             };
         }
 
-        private static RollSignificance GetRollSignificance(int value, DieType dieType)
+        private static RollSignificance GetRollSignificance(int value, DieType? dieType)
         {
             return dieType switch
             {
@@ -268,47 +232,9 @@ namespace DotDice.Evaluator
             };
         }
 
-        private List<rollResult> ApplyModifiers(List<rollResult> rolls, IEnumerable<Modifier> modifiers)
-        {
-            foreach (var modifier in modifiers)
-            {
-                switch (modifier)
-                {
-                    case CompoundingModifier compoundingModifier:
-                        rolls = ApplyCompoundingModifier(rolls, compoundingModifier);
-                        break;
-                    case ConstantModifier constantModifier:
-                        rolls = ApplyConstantModifier(rolls, constantModifier);
-                        break;
-                    case DropModifier dropModifier:
-                        rolls = ApplyDropModifier(rolls, dropModifier);
-                        break;
-                    case ExplodeModifier explodeModifier:
-                        rolls = ApplyExplodeModifier(rolls, explodeModifier);
-                        break;
-                    case FailureModifier failureModifier:
-                        rolls = ApplyFailureModifier(rolls, failureModifier);
-                        break;
-                    case KeepModifier keepModifier:
-                        rolls = ApplyKeepModifier(rolls, keepModifier);
-                        break;
-                    case RerollOnceModifier rerollOnceModifier:
-                        rolls = ApplyRerollOnceModifier(rolls, rerollOnceModifier);
-                        break;
-                    case RerollMultipleModifier rerollUntilModifier:
-                        rolls = ApplyRerollUntilModifier(rolls, rerollUntilModifier);
-                        break;
-                    case SuccessModifier successModifier:
-                        rolls = ApplySuccessModifier(rolls, successModifier);
-                        break;
-                }
-            }
-            return rolls;
-        }
-
         private List<DieEvent> ApplyModifiersDetailed(List<DieEvent> events, IEnumerable<Modifier> modifiers, DieType originalDieType)
         {
-            // Phase 1: Generation Phase - Creates Events 
+            // Phase 1: Generation Phase - Creates Events
             // Handle Initial rolls (already done), Reroll, then Explosion/Compound
             foreach (var modifier in modifiers)
             {
@@ -345,121 +271,25 @@ namespace DotDice.Evaluator
             }
 
             // Phase 3: Finalization Phase - Reads Events
-            // Apply Success/Failure interpretations and handle constants
+            // Success and failure counting are applied together against the same dice,
+            // so expressions like "6d10>8f<2" produce (successes - failures).
+            var successModifier = modifiers.OfType<SuccessModifier>().FirstOrDefault();
+            var failureModifier = modifiers.OfType<FailureModifier>().FirstOrDefault();
+
+            if (successModifier != null || failureModifier != null)
+            {
+                events = ApplySuccessFailureModifiersDetailed(events, successModifier, failureModifier);
+            }
+
             foreach (var modifier in modifiers)
             {
-                switch (modifier)
+                if (modifier is ConstantModifier constantModifier)
                 {
-                    case SuccessModifier successModifier:
-                        events = ApplySuccessModifierDetailed(events, successModifier);
-                        break;
-                    case FailureModifier failureModifier:
-                        events = ApplyFailureModifierDetailed(events, failureModifier);
-                        break;
-                    case ConstantModifier constantModifier:
-                        events = ApplyConstantModifierDetailed(events, constantModifier);
-                        break;
+                    events = ApplyConstantModifierDetailed(events, constantModifier);
                 }
             }
 
             return events;
-        }
-
-        /// <summary>
-        /// Compounding modifier is similar to explode, but instead of adding new dice,
-        /// it adds the result of additional rolls to the original die's result.
-        /// For example, if rolling a d6 and the condition is >= 6, and you roll a 6,
-        /// you roll another d6 and add its result to the original 6, continuing if that roll also meets the condition.
-        /// To prevent infinite loops, we limit the number of compounds to 100 per die by default.
-        /// </summary>
-        /// <param name="rolls">The original roll results</param>
-        /// <param name="compoundingModifier">The compounding modifier containing the comparison criteria</param>
-        /// <returns>Updated list of rollResults with compounded values</returns>
-        private List<rollResult> ApplyCompoundingModifier(List<rollResult> rolls, CompoundingModifier compoundingModifier)
-        {
-            var result = new List<rollResult>();
-
-            // Process each original roll
-            foreach (var roll in rolls)
-            {
-                // Skip static dice types (constant, success)
-                if (roll.type is DieType.Constant || roll.type is DieType.Success)
-                {
-                    result.Add(roll);
-                    continue;
-                }
-
-                // Set up for compounding
-                int totalValue = roll.result;
-                int compoundCounter = 0;
-                var currentRoll = roll;
-
-                // As long as we meet the condition and haven't hit the limit, keep compounding
-                while (compoundCounter < MaxCompounds &&
-                    Compare(currentRoll.result, compoundingModifier.Operator, compoundingModifier.Value))
-                {
-                    // Roll another die of the same type
-                    DieType newDieType = currentRoll.type switch
-                    {
-                        DieType.Basic basic => new DieType.Basic(basic.sides),
-                        DieType.Percent => new DieType.Percent(),
-                        DieType.Fudge => new DieType.Fudge(),
-                        _ => currentRoll.type // Use existing type if not specifically handled
-                    };
-
-                    // Roll the new die and add its value to the total
-                    currentRoll = RollDie(newDieType);
-                    totalValue += currentRoll.result;
-
-                    // Increment the counter to prevent infinite loops
-                    compoundCounter++;
-                }
-
-                // Add a single roll with the compounded value
-                result.Add(new rollResult(totalValue, roll.type));
-            }
-            return result;
-        }
-
-        private List<rollResult> ApplyKeepModifier(List<rollResult> rolls, KeepModifier keepModifier)
-        {
-            return ApplyKeepOrDropModifier(rolls, keepModifier.Count, keepModifier.KeepHighest, isKeep: true);
-        }
-
-        private List<rollResult> ApplyDropModifier(List<rollResult> rolls, DropModifier dropModifier)
-        {
-            return ApplyKeepOrDropModifier(rolls, dropModifier.Count, dropModifier.DropHighest, isKeep: false);
-        }
-
-        private List<rollResult> ApplyKeepOrDropModifier(List<rollResult> rolls, int count, bool selectHighest, bool isKeep)
-        {
-            var staticRolls = rolls.Where(x => x.type is DieType.Constant || x.type is DieType.Success)
-                .ToList();
-            var dynamicRolls = rolls.Where(x => x.type is not DieType.Constant && x.type is not DieType.Success)
-                .ToList();
-
-            var ordered = selectHighest 
-                ? dynamicRolls.OrderByDescending(x => x.result)
-                : dynamicRolls.OrderBy(x => x.result);
-
-            var selected = isKeep 
-                ? ordered.Take(count)
-                : ordered.Skip(count);
-
-            return selected.Concat(staticRolls).ToList();
-        }
-
-        private List<rollResult> ApplyConstantModifier(List<rollResult> rolls, ConstantModifier constantModifier)
-        {
-            //Constant should be applied after everything else, and just add a value to the total of all rolls, not individual rolls
-            var value = constantModifier.Operator switch
-            {
-                ArithmeticOperator.Add => constantModifier.Value,
-                ArithmeticOperator.Subtract => -constantModifier.Value,
-                _ => throw new InvalidEnumArgumentException("Invalid ArithmeticOperator")
-            };
-            return rolls.Append(new(value, new DieType.Constant()))
-                .ToList();
         }
 
         private bool Compare(int rollResult, ComparisonOperator comparisonOperator, int modifierValue)
@@ -473,146 +303,6 @@ namespace DotDice.Evaluator
             };
         }
 
-        /// <summary>
-        /// Reroll once modifier will reroll any dice that meets the condition once.
-        /// </summary>
-        /// <param name="rolls"></param>
-        /// <param name="rerollOnceModifier"></param>
-        /// <returns>Updated list of rollResult</returns>
-        private List<rollResult> ApplyRerollOnceModifier(List<rollResult> rolls, RerollOnceModifier rerollOnceModifier)
-        {
-            return rolls.Select(roll =>
-            {
-                if (roll.type is DieType.Constant || roll.type is DieType.Success)
-                {
-                    return roll;
-                }
-                var comparison = Compare(roll.result, rerollOnceModifier.Operator, rerollOnceModifier.Value);
-                return comparison ? RollDie(new DieType.Reroll(roll.result)) : roll;
-            })
-                .ToList();
-        }
-
-        /// <summary>
-        /// Reroll once modifier will reroll any dice that meets the condition until success.
-        /// In order to avoid infinite loop, we need to limit the number of rerolls.
-        /// </summary>
-        /// <param name="rolls"></param>
-        /// <param name="rerollOnceModifier"></param>
-        /// <returns>Updated list of rollResults with re-rolled values</returns>
-        private List<rollResult> ApplyRerollUntilModifier(List<rollResult> rolls, RerollMultipleModifier rerollUntilModifier)
-        {
-            return rolls.Select(roll =>
-            {
-                if (roll.type is DieType.Constant || roll.type is DieType.Success)
-                {
-                    return roll;
-                }
-
-                var comparison = Compare(roll.result, rerollUntilModifier.Operator, rerollUntilModifier.Value);
-                var maxRerolls = 10;
-                while (comparison && maxRerolls-- > 0)
-                {
-                    roll = RollDie(new DieType.Reroll(roll.result));
-                    comparison = Compare(roll.result, rerollUntilModifier.Operator, rerollUntilModifier.Value);
-                }
-                return roll;
-            })
-            .ToList();
-        }
-
-        /// <summary>
-        /// Explode modifier will add additional dice for each die that meets the condition.
-        /// For example, if the condition is > 5 on a d6, and you roll a 6, then you get to roll
-        /// another d6 and add it to your total. If that d6 also rolls a 6, you roll again, etc.
-        /// To prevent infinite loops, we limit the number of explosions to 100 per die by default.
-        /// </summary>
-        /// <param name="rolls">The original roll results</param>
-        /// <param name="explodeModifier">The explode modifier containing the comparison criteria</param>
-        /// <returns>Updated list of rollResults with additional dice for those that exploded</returns>
-        private List<rollResult> ApplyExplodeModifier(List<rollResult> rolls, ExplodeModifier explodeModifier)
-        {
-            var result = new List<rollResult>();
-
-            // Process each original roll
-            foreach (var roll in rolls)
-            {
-                // Add the original roll to the result
-                result.Add(roll);
-
-                // Skip static dice types (constant, success)
-                if (roll.type is DieType.Constant || roll.type is DieType.Success)
-                {
-                    continue;
-                }
-
-                // Check for explosion chain
-                var currentRoll = roll;
-                int explosionCounter = 0;
-
-                while (explosionCounter < MaxExplosions &&
-                      Compare(currentRoll.result, explodeModifier.Operator, explodeModifier.Value))
-                {
-                    // Roll another die of the same type
-                    DieType newDieType = currentRoll.type switch
-                    {
-                        DieType.Basic basic => new DieType.Basic(basic.sides),
-                        DieType.Percent => new DieType.Percent(),
-                        DieType.Fudge => new DieType.Fudge(),
-                        _ => currentRoll.type // Use existing type if not specifically handled
-                    };
-
-                    // Roll the new die
-                    currentRoll = RollDie(newDieType);
-
-                    // Add the new roll to the result
-                    result.Add(currentRoll);
-
-                    // Increment the counter to prevent infinite loops
-                    explosionCounter++;
-                }
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Counts dice that meet the success criteria and returns a roll with the count as a Success type.
-        /// </summary>
-        /// <param name="rolls">The original roll results</param>
-        /// <param name="successModifier">The success modifier containing the comparison criteria</param>
-        /// <returns>A list with a single rollResult of type Success containing the count of successful dice</returns>
-        private List<rollResult> ApplySuccessModifier(List<rollResult> rolls, SuccessModifier successModifier)
-        {
-            // Only count dynamic dice (not constants or existing success rolls)
-            var successCount = rolls.Count(roll =>
-                roll.type is not DieType.Constant &&
-                roll.type is not DieType.Success &&
-                Compare(roll.result, successModifier.Operator, successModifier.Value));
-
-            // Return a single Success roll with the count of successes
-            return new List<rollResult> { new rollResult(successCount, new DieType.Success()) };
-        }
-
-        /// <summary>
-        /// Counts dice that meet the failure criteria and returns a roll with the negative count as a Success type.
-        /// </summary>
-        /// <param name="rolls">The original roll results</param>
-        /// <param name="failureModifier">The failure modifier containing the comparison criteria</param>
-        /// <returns>A list with a single rollResult of type Success containing the negative count of failed dice</returns>
-        private List<rollResult> ApplyFailureModifier(List<rollResult> rolls, FailureModifier failureModifier)
-        {
-            // Only count dynamic dice (not constants or existing success rolls)
-
-            var failureCount = rolls.Count(roll =>
-                roll.type is not DieType.Constant &&
-                roll.type is not DieType.Success &&
-                Compare(roll.result, failureModifier.Operator, failureModifier.Value));
-
-            // Return a single Success roll with the negative count of failures
-            return new List<rollResult> { new rollResult(-failureCount, new DieType.Success()) };
-        }
-
         #region Detailed Modifier Methods
 
         private List<DieEvent> ApplyRerollOnceModifierDetailed(List<DieEvent> events, RerollOnceModifier rerollOnceModifier, DieType originalDieType)
@@ -624,7 +314,7 @@ namespace DotDice.Evaluator
                 var evt = events[i];
 
                 // Skip non-rollable events
-                if (evt.Status == DieStatus.Discarded || 
+                if (evt.Status == DieStatus.Discarded ||
                     !ShouldProcessEvent(evt))
                 {
                     continue;
@@ -654,16 +344,16 @@ namespace DotDice.Evaluator
                 var evt = events[i];
 
                 // Skip non-rollable events
-                if (evt.Status == DieStatus.Discarded || 
+                if (evt.Status == DieStatus.Discarded ||
                     !ShouldProcessEvent(evt))
                 {
                     continue;
                 }
 
                 var currentEvent = evt;
-                var maxRerolls = 10;
-                
-                while (maxRerolls-- > 0 && 
+                var maxRerolls = MaxRerolls;
+
+                while (maxRerolls-- > 0 &&
                        Compare(currentEvent.Value, rerollUntilModifier.Operator, rerollUntilModifier.Value))
                 {
                     // Mark current as discarded
@@ -688,7 +378,7 @@ namespace DotDice.Evaluator
                 var evt = events[i];
 
                 // Skip non-rollable events
-                if (evt.Status == DieStatus.Discarded || 
+                if (evt.Status == DieStatus.Discarded ||
                     !ShouldProcessEvent(evt))
                 {
                     continue;
@@ -718,7 +408,7 @@ namespace DotDice.Evaluator
             foreach (var evt in events)
             {
                 // Skip non-rollable events
-                if (evt.Status == DieStatus.Discarded || 
+                if (evt.Status == DieStatus.Discarded ||
                     !ShouldProcessEvent(evt))
                 {
                     result.Add(evt);
@@ -738,7 +428,7 @@ namespace DotDice.Evaluator
                     // Create compound event (preserve group information from original event)
                     var compoundEvent = RollDieEvent(originalDieType, DieEventType.Compound, evt.GroupId, evt.GroupOperator);
                     compoundEvents.Add(compoundEvent);
-                    
+
                     // Add to total value
                     totalValue += compoundEvent.Value;
                     currentValue = compoundEvent.Value;
@@ -754,11 +444,13 @@ namespace DotDice.Evaluator
                     DieType = evt.DieType,
                     Significance = GetRollSignificance(totalValue, evt.DieType),
                     Status = evt.Status,
-                    Success = evt.Success
+                    Success = evt.Success,
+                    GroupId = evt.GroupId,
+                    GroupOperator = evt.GroupOperator
                 };
 
                 result.Add(finalEvent);
-                
+
                 // Add the compound events for transparency (but mark them as discarded so they don't count in final sum)
                 foreach (var compoundEvent in compoundEvents)
                 {
@@ -792,7 +484,7 @@ namespace DotDice.Evaluator
                 // Keep all if we have fewer than or equal to the keep count
                 return;
             }
-            
+
             if (!isKeep && rollableEvents.Count <= count)
             {
                 // Drop all if we have fewer than or equal to the drop count
@@ -834,62 +526,42 @@ namespace DotDice.Evaluator
             }
         }
 
-        private List<DieEvent> ApplySuccessModifierDetailed(List<DieEvent> events, SuccessModifier successModifier)
+        /// <summary>
+        /// Applies success and/or failure counting against the same set of active dice.
+        /// Each active die is compared against the success criteria first, then the failure
+        /// criteria (a die can only count once; success takes precedence when criteria overlap).
+        /// Returns a single count event whose value is (successes - failures), so:
+        ///   success-only  => successCount
+        ///   failure-only  => -failureCount
+        ///   both          => successCount - failureCount (e.g. World of Darkness botch rules)
+        /// </summary>
+        private List<DieEvent> ApplySuccessFailureModifiersDetailed(List<DieEvent> events, SuccessModifier? successModifier, FailureModifier? failureModifier)
         {
-            // Update success status for rollable events
             foreach (var evt in events)
             {
-                if (evt.Status != DieStatus.Discarded && 
+                if (evt.Status != DieStatus.Discarded &&
                     evt.Status != DieStatus.Dropped &&
                     ShouldProcessEvent(evt))
                 {
-                    if (Compare(evt.Value, successModifier.Operator, successModifier.Value))
+                    if (successModifier != null && Compare(evt.Value, successModifier.Operator, successModifier.Value))
                     {
                         evt.Success = SuccessStatus.Success;
                     }
-                }
-            }
-
-            // Count successes and replace with a single success event
-            var successCount = events.Count(e => e.Success == SuccessStatus.Success);
-            
-            return new List<DieEvent>
-            {
-                new DieEvent
-                {
-                    Value = successCount,
-                    Type = DieEventType.Initial,
-                    Significance = RollSignificance.None,
-                    Status = DieStatus.Kept,
-                    Success = SuccessStatus.Neutral
-                }
-            };
-        }
-
-        private List<DieEvent> ApplyFailureModifierDetailed(List<DieEvent> events, FailureModifier failureModifier)
-        {
-            // Update failure status for rollable events
-            foreach (var evt in events)
-            {
-                if (evt.Status != DieStatus.Discarded && 
-                    evt.Status != DieStatus.Dropped &&
-                    ShouldProcessEvent(evt))
-                {
-                    if (Compare(evt.Value, failureModifier.Operator, failureModifier.Value))
+                    else if (failureModifier != null && Compare(evt.Value, failureModifier.Operator, failureModifier.Value))
                     {
                         evt.Success = SuccessStatus.Failure;
                     }
                 }
             }
 
-            // Count failures and return as negative
+            var successCount = events.Count(e => e.Success == SuccessStatus.Success);
             var failureCount = events.Count(e => e.Success == SuccessStatus.Failure);
-            
+
             return new List<DieEvent>
             {
                 new DieEvent
                 {
-                    Value = -failureCount,
+                    Value = successCount - failureCount,
                     Type = DieEventType.Initial,
                     Significance = RollSignificance.None,
                     Status = DieStatus.Kept,
@@ -922,10 +594,10 @@ namespace DotDice.Evaluator
         private static bool ShouldProcessEvent(DieEvent evt)
         {
             // Process events that represent actual dice rolls (not constants)
-            // Constants would have Type = Initial but represent +N modifiers 
-            return evt.Type == DieEventType.Initial || 
-                   evt.Type == DieEventType.Reroll || 
-                   evt.Type == DieEventType.Explosion || 
+            // Constants would have Type = Initial but represent +N modifiers
+            return evt.Type == DieEventType.Initial ||
+                   evt.Type == DieEventType.Reroll ||
+                   evt.Type == DieEventType.Explosion ||
                    evt.Type == DieEventType.Compound;
         }
 

--- a/DotDice/src/Extension/StringExtensions.cs
+++ b/DotDice/src/Extension/StringExtensions.cs
@@ -20,7 +20,11 @@ namespace DotDice.Extension
             var parser = DiceParser.Roll.Parse(input);
             if (parser is null || !parser.Success)
             {
-                throw new FormatException("Invalid roll format.");
+                // Include the parser's diagnostic (position, expected tokens) so callers
+                // can surface a useful message instead of a generic failure.
+                throw new FormatException(parser is null
+                    ? "Invalid roll format."
+                    : $"Invalid roll format. {parser.Error}".TrimEnd());
             }
 
             var evaluator = randomNumberGenerator != null 
@@ -42,7 +46,11 @@ namespace DotDice.Extension
             var parser = DiceParser.Roll.Parse(input);
             if (parser is null || !parser.Success)
             {
-                throw new FormatException("Invalid roll format.");
+                // Include the parser's diagnostic (position, expected tokens) so callers
+                // can surface a useful message instead of a generic failure.
+                throw new FormatException(parser is null
+                    ? "Invalid roll format."
+                    : $"Invalid roll format. {parser.Error}".TrimEnd());
             }
 
             var evaluator = randomNumberGenerator != null 

--- a/DotDice/src/Parser/DiceParser.cs
+++ b/DotDice/src/Parser/DiceParser.cs
@@ -9,6 +9,13 @@ namespace DotDice.Parser
 
     public static class DiceParser
     {
+        /// <summary>
+        /// Sentinel value used by shorthand modifiers (bare "!", "!!", "^") to mean
+        /// "the maximum face of the die". It is replaced with the concrete face value
+        /// when the enclosing basic roll is constructed, so it never escapes a full parse.
+        /// </summary>
+        public const int MaxFaceSentinel = -1;
+
         static Parser<char, int> PositiveInt =
             DecimalNum.Where(x => x > 0);
 
@@ -35,6 +42,20 @@ namespace DotDice.Parser
                 )
             );
 
+        // Unsigned digits-only positive integer. Unlike DecimalNum this rejects a
+        // leading '+'/'-', so shorthand like "2d6!" followed by "+3" leaves the
+        // "+3" for the arithmetic-expression parser instead of consuming it.
+        static readonly Parser<char, int> UnsignedPositiveInt =
+            Digit.AtLeastOnceString()
+                .Select(s => int.TryParse(s, out var v) ? v : -1)
+                .Where(x => x > 0);
+
+        // Comparison point that also accepts a bare integer as shorthand for equality,
+        // so "ro1" means "ro=1" and "!6" means "!=6" (matching common VTT syntax).
+        public static readonly Parser<char, ComparisonPoint> comparisonPointOrBareValue =
+            comparisonPoint
+                .Or(Tok(UnsignedPositiveInt).Map(val => new ComparisonPoint(ComparisonOperator.Equal, val)));
+
         // Parser for success modifier
         public static readonly Parser<char, Modifier> successModifier =
             Tok(
@@ -51,42 +72,50 @@ namespace DotDice.Parser
                 )
             );
 
-        // Parser for explode modifier
+        // Parser for explode modifier.
+        // The comparison is optional: bare "!" explodes on the die's maximum face
+        // (resolved from MaxFaceSentinel when the enclosing roll is built), and a
+        // bare integer is shorthand for equality ("3d6!6" == "3d6!=6").
         public static readonly Parser<char, Modifier> explodeModifier =
             Tok(
                 Char('!').
                 Then(
-                    comparisonPoint,
-                    (_, cp) => (Modifier)new ExplodeModifier(cp.compOp, cp.value)
+                    comparisonPointOrBareValue.Optional(),
+                    (_, maybeCp) => maybeCp.HasValue
+                        ? (Modifier)new ExplodeModifier(maybeCp.Value.compOp, maybeCp.Value.value)
+                        : (Modifier)new ExplodeModifier(ComparisonOperator.Equal, MaxFaceSentinel)
                 )
             );
 
-        // Parser for compounding modifier
+        // Parser for compounding modifier ("^" or the common VTT alias "!!").
+        // The comparison is optional, with the same shorthand rules as explode.
         public static readonly Parser<char, Modifier> compoundingModifier =
             Tok(
-                Char('^').
+                Try(String("!!")).Or(Char('^').Map(c => c.ToString())).
                 Then(
-                    comparisonPoint,
-                    (_, cp) => (Modifier)new CompoundingModifier(cp.compOp, cp.value)
+                    comparisonPointOrBareValue.Optional(),
+                    (_, maybeCp) => maybeCp.HasValue
+                        ? (Modifier)new CompoundingModifier(maybeCp.Value.compOp, maybeCp.Value.value)
+                        : (Modifier)new CompoundingModifier(ComparisonOperator.Equal, MaxFaceSentinel)
                 )
             );
 
-        // Parser for reroll modifier
+        // Parser for reroll modifier ("ro=1" or the shorthand "ro1")
         public static readonly Parser<char, Modifier> rerollOnceModifier =
             Tok(
                 String("ro")
                 .Then(
-                    comparisonPoint,
+                    comparisonPointOrBareValue,
                     (_, cp) => (Modifier)new RerollOnceModifier(cp.compOp, cp.value)
                 )
             );
 
-        // Parser for reroll modifier
+        // Parser for reroll modifier ("rc<2" or the shorthand "rc1")
         public static readonly Parser<char, Modifier> rerollCompoundModifier =
             Tok(
                 String("rc")
                 .Then(
-                    comparisonPoint,
+                    comparisonPointOrBareValue,
                     (_, cp) => (Modifier)new RerollMultipleModifier(cp.compOp, cp.value)
                 )
             );
@@ -161,7 +190,9 @@ namespace DotDice.Parser
                 )
             );
 
-        // Parser for a single modifier
+        // Parser for a single modifier.
+        // Note: compoundingModifier must be tried before explodeModifier so "!!" is
+        // recognised as a compound rather than two bare explodes.
         public static readonly Parser<char, Modifier> Modifier =
             successModifier
                 .Or(failureModifier)
@@ -171,8 +202,8 @@ namespace DotDice.Parser
                 .Or(keepLowModifier)
                 .Or(rerollOnceModifier)
                 .Or(rerollCompoundModifier)
-                .Or(explodeModifier)
                 .Or(compoundingModifier)
+                .Or(explodeModifier)
                 .Or(constantModifier);
 
         // Parser for multiple modifiers
@@ -196,6 +227,30 @@ namespace DotDice.Parser
                     .Map(val => (DieType)new DieType.Basic(val)))
             );
 
+        /// <summary>
+        /// Replaces MaxFaceSentinel placeholders (from bare "!", "!!", "^") with the
+        /// concrete maximum face value of the die being rolled.
+        /// </summary>
+        private static IEnumerable<Modifier> ResolveMaxFaceSentinels(IEnumerable<Modifier> modifiers, DieType die)
+        {
+            int maxFace = die switch
+            {
+                DieType.Basic basic => basic.sides,
+                DieType.Percent => 100,
+                DieType.Fudge => 1,
+                _ => MaxFaceSentinel
+            };
+
+            return modifiers
+                .Select<Modifier, Modifier>(m => m switch
+                {
+                    ExplodeModifier { Value: MaxFaceSentinel } => new ExplodeModifier(ComparisonOperator.Equal, maxFace),
+                    CompoundingModifier { Value: MaxFaceSentinel } => new CompoundingModifier(ComparisonOperator.Equal, maxFace),
+                    _ => m
+                })
+                .ToList();
+        }
+
         // Parser for a basic roll
         public static readonly Parser<char, Roll> basicRoll =
             Tok(
@@ -204,7 +259,7 @@ namespace DotDice.Parser
                         (Roll)new BasicRoll(
                             maybeNum.HasValue ? maybeNum.Value : 1,
                             die,
-                            mod
+                            ResolveMaxFaceSentinels(mod, die)
                         )
                     ,
                     PositiveInt.Optional(),
@@ -224,7 +279,8 @@ namespace DotDice.Parser
                     .ThenReturn(ArithmeticOperator.Subtract))
             );
 
-        // Parser for a single modifier (excluding constant modifiers for arithmetic expressions)
+        // Parser for a single modifier (excluding constant modifiers for arithmetic expressions).
+        // compoundingModifier before explodeModifier, as above.
         public static readonly Parser<char, Modifier> ModifierExcludingConstant =
             successModifier
                 .Or(failureModifier)
@@ -234,8 +290,8 @@ namespace DotDice.Parser
                 .Or(keepLowModifier)
                 .Or(rerollOnceModifier)
                 .Or(rerollCompoundModifier)
-                .Or(explodeModifier)
-                .Or(compoundingModifier);
+                .Or(compoundingModifier)
+                .Or(explodeModifier);
 
         // Parser for multiple modifiers (excluding constant modifiers)
         public static readonly Parser<char, IEnumerable<Modifier>> ModifiersExcludingConstant = ModifierExcludingConstant.Many();
@@ -248,7 +304,7 @@ namespace DotDice.Parser
                         (Roll)new BasicRoll(
                             maybeNum.HasValue ? maybeNum.Value : 1,
                             die,
-                            mod
+                            ResolveMaxFaceSentinels(mod, die)
                         )
                     ,
                     PositiveInt.Optional(),

--- a/DotDiceTests/src/BugFixTests.cs
+++ b/DotDiceTests/src/BugFixTests.cs
@@ -1,0 +1,321 @@
+using DotDice.Evaluator;
+using DotDice.Extension;
+using DotDice.Parser;
+using DotDice.RandomNumberGenerator;
+using static DotDice.Tests.DiceEvaluatorTests;
+
+namespace DotDice.Tests
+{
+    /// <summary>
+    /// Regression tests for the fixes on the dotDice branch:
+    ///  1. Rerolls must roll the original die, not a die whose sides equal the previous result.
+    ///  2. Success + failure modifiers combined must count both against the same dice.
+    ///  3. MaxRerolls is configurable and validated.
+    ///  4. Evaluate() and EvaluateDetailed() share one implementation and always agree.
+    ///  5. Grammar shorthands (bare "!", "!!", "^", "ro1", "rc2") evaluate correctly.
+    ///  6. Parse failures carry a diagnostic message.
+    /// </summary>
+    [TestFixture]
+    public class BugFixTests
+    {
+        /// <summary>
+        /// RNG that records the (min, max) range of every ranged call, so tests can
+        /// assert which die was actually rolled (a scripted mock alone can't catch
+        /// a wrong side count because it ignores the requested range).
+        /// </summary>
+        private class RangeRecordingRandomNumberGenerator : IRandomNumberGenerator<int>
+        {
+            private readonly Queue<int> _values;
+            public List<(int min, int max)> RangedCalls { get; } = new();
+
+            public RangeRecordingRandomNumberGenerator(IEnumerable<int> values)
+            {
+                _values = new Queue<int>(values);
+            }
+
+            public int Next() => _values.Dequeue();
+
+            public int Next(int maxValue) => _values.Dequeue();
+
+            public int Next(int minValue, int maxValue)
+            {
+                RangedCalls.Add((minValue, maxValue));
+                return _values.Dequeue();
+            }
+
+            public void SetSeed(int seed) { /* No-op for testing */ }
+
+            public int GetSeed() => throw new NotImplementedException();
+        }
+
+        #region Reroll uses the original die's sides
+
+        [Test]
+        public void RerollOnce_ParseRoll_RerollsUseOriginalDieSides()
+        {
+            // 3d6ro=1 with a 1 in the pool: the reroll must request a d6 range (1..7),
+            // not a range derived from the previous result (the old bug rolled a "d1").
+            var rng = new RangeRecordingRandomNumberGenerator(new List<int> { 1, 4, 6, 5 });
+            var result = "3d6ro=1".ParseRoll(rng);
+
+            Assert.That(result, Is.EqualTo(15)); // 5 (reroll) + 4 + 6
+            Assert.That(rng.RangedCalls.Count, Is.EqualTo(4), "3 initial rolls + 1 reroll");
+            Assert.That(rng.RangedCalls, Is.All.EqualTo((1, 7)),
+                "Every roll, including the reroll, must be rolled on the original d6");
+        }
+
+        [Test]
+        public void RerollMultiple_ParseRoll_RerollsUseOriginalDieSides()
+        {
+            // 1d10rc<3: 2 -> 1 -> 7. Both rerolls must be on a d10 (1..11).
+            var rng = new RangeRecordingRandomNumberGenerator(new List<int> { 2, 1, 7 });
+            var result = "1d10rc<3".ParseRoll(rng);
+
+            Assert.That(result, Is.EqualTo(7));
+            Assert.That(rng.RangedCalls, Is.All.EqualTo((1, 11)),
+                "Every reroll must be rolled on the original d10");
+        }
+
+        [Test]
+        public void RerollOnce_SeededRealRng_AllEventsWithinDieRange()
+        {
+            // Property-style check with the real RNG: no event value can ever leave 1..6.
+            for (int seed = 0; seed < 50; seed++)
+            {
+                var result = "10d6ro<3".ParseRollDetailed(new RandomIntGenerator(seed));
+
+                Assert.That(result.Events.Select(e => e.Value), Is.All.InRange(1, 6),
+                    $"Seed {seed}: rerolled dice must stay within the d6 range");
+                Assert.That(result.Value, Is.InRange(10, 60), $"Seed {seed}: total out of range");
+            }
+        }
+
+        #endregion
+
+        #region Success + failure combined
+
+        [Test]
+        public void SuccessAndFailure_ParseRoll_ReturnsSuccessesMinusFailures()
+        {
+            // World of Darkness style: 6d10, successes on 9+, botches below 2.
+            // Rolls: 9, 1, 10, 5, 1, 8 -> successes {9, 10} = 2, failures {1, 1} = 2, net 0.
+            var rng = new TestHelpers.MockRandomNumberGenerator(new List<int> { 9, 1, 10, 5, 1, 8 });
+            var result = "6d10>8f<2".ParseRoll(rng);
+
+            Assert.That(result, Is.EqualTo(0), "2 successes - 2 failures should be 0");
+        }
+
+        [Test]
+        public void SuccessAndFailure_ParseRollDetailed_ReturnsSuccessesMinusFailures()
+        {
+            // Rolls: 8, 1, 9, 3, 10 -> successes {8, 9, 10} = 3, failures {1} = 1, net 2.
+            var rng = new TestHelpers.MockRandomNumberGenerator(new List<int> { 8, 1, 9, 3, 10 });
+            var result = "5d10>7f=1".ParseRollDetailed(rng);
+
+            Assert.That(result.Value, Is.EqualTo(2), "3 successes - 1 failure should be 2");
+            Assert.That(result.Events.Count, Is.EqualTo(1), "Success/failure counting returns a single count event");
+        }
+
+        [Test]
+        public void SuccessAndFailure_OverlappingCriteria_SuccessTakesPrecedence()
+        {
+            // ">2" and "f>4" overlap for a 6: the 6 counts as a success, not a failure.
+            // Rolls: 6, 3, 1 -> successes {6, 3} = 2, failures {} (1 matches neither), net 2.
+            var rng = new TestHelpers.MockRandomNumberGenerator(new List<int> { 6, 3, 1 });
+            var result = "3d6>2f>4".ParseRoll(rng);
+
+            Assert.That(result, Is.EqualTo(2), "A die matching both criteria must only count as a success");
+        }
+
+        [Test]
+        public void SuccessOnly_And_FailureOnly_BehaviorUnchanged()
+        {
+            var rng1 = new TestHelpers.MockRandomNumberGenerator(new List<int> { 5, 3, 6, 2 });
+            Assert.That("4d6>4".ParseRoll(rng1), Is.EqualTo(2), "Success-only counting unchanged");
+
+            var rng2 = new TestHelpers.MockRandomNumberGenerator(new List<int> { 5, 3, 6, 2 });
+            Assert.That("4d6f<3".ParseRoll(rng2), Is.EqualTo(-1), "Failure-only counting unchanged");
+        }
+
+        [Test]
+        public void SuccessAndFailure_WithKeptAndDroppedDice_OnlyCountsActiveDice()
+        {
+            // 4d10kh2>7f<3: keep the two highest (9, 8), then count successes/failures
+            // among the kept dice only. 9 and 8 are successes -> 2; dropped 2 and 5 don't count.
+            var rng = new TestHelpers.MockRandomNumberGenerator(new List<int> { 9, 2, 8, 5 });
+            var result = "4d10kh2>7f<3".ParseRoll(rng);
+
+            Assert.That(result, Is.EqualTo(2), "Dropped dice must not count toward successes or failures");
+        }
+
+        #endregion
+
+        #region MaxRerolls
+
+        [Test]
+        public void MaxRerolls_SetBelowOne_Throws()
+        {
+            var evaluator = new DiceEvaluator();
+            Assert.Throws<ArgumentOutOfRangeException>(() => evaluator.MaxRerolls = 0);
+        }
+
+        [Test]
+        public void MaxRerolls_DefaultLimitsRerollChain()
+        {
+            // rc<7 on a d6 always matches, so the chain stops at the MaxRerolls default (10):
+            // 1 initial event + 10 reroll events.
+            var evaluator = new DiceEvaluator(new RepeatingRandomNumberGenerator(1));
+            var roll = new BasicRoll(1, new DieType.Basic(6),
+                new List<Modifier> { new RerollMultipleModifier(ComparisonOperator.LessThan, 7) });
+
+            var result = evaluator.EvaluateDetailed(roll);
+
+            Assert.That(result.Events.Count, Is.EqualTo(11), "1 initial + 10 rerolls (default MaxRerolls)");
+        }
+
+        [Test]
+        public void MaxRerolls_CustomValueLimitsRerollChain()
+        {
+            var evaluator = new DiceEvaluator(new RepeatingRandomNumberGenerator(1));
+            evaluator.MaxRerolls = 3;
+            var roll = new BasicRoll(1, new DieType.Basic(6),
+                new List<Modifier> { new RerollMultipleModifier(ComparisonOperator.LessThan, 7) });
+
+            var result = evaluator.EvaluateDetailed(roll);
+
+            Assert.That(result.Events.Count, Is.EqualTo(4), "1 initial + 3 rerolls (custom MaxRerolls)");
+        }
+
+        #endregion
+
+        #region Evaluate and EvaluateDetailed agree
+
+        // A corpus of expressions covering every modifier; with the same seed both
+        // APIs must produce the same value, guarding against the two paths diverging again.
+        [TestCase("3d6")]
+        [TestCase("4d6kh3")]
+        [TestCase("4d6dl1")]
+        [TestCase("2d20kl1")]
+        [TestCase("3d6!=6")]
+        [TestCase("2d6^=6")]
+        [TestCase("4d6ro=1")]
+        [TestCase("4d6rc<3")]
+        [TestCase("8d6>4")]
+        [TestCase("8d6f<2")]
+        [TestCase("6d10>8f<2")]
+        [TestCase("4d6kh3+5")]
+        [TestCase("3d20+5d6-1d4+1")]
+        [TestCase("2d6!")]
+        [TestCase("2d6!!")]
+        [TestCase("4d6ro1dl1")]
+        [TestCase("d%")]
+        [TestCase("4dF+2")]
+        public void Evaluate_And_EvaluateDetailed_AgreeForSameSeed(string expression)
+        {
+            for (int seed = 0; seed < 25; seed++)
+            {
+                var simple = expression.ParseRoll(new RandomIntGenerator(seed));
+                var detailed = expression.ParseRollDetailed(new RandomIntGenerator(seed));
+
+                Assert.That(detailed.Value, Is.EqualTo(simple),
+                    $"'{expression}' (seed {seed}): Evaluate and EvaluateDetailed must agree");
+            }
+        }
+
+        #endregion
+
+        #region Shorthand evaluation
+
+        [Test]
+        public void BareExplode_EvaluatesAsExplodeOnMaxFace()
+        {
+            // 3d6!: 6 explodes -> 2; total 6+3+4+2 = 15 (same as "3d6!=6")
+            var rng = new TestHelpers.MockRandomNumberGenerator(new List<int> { 6, 3, 4, 2 });
+            var result = "3d6!".ParseRoll(rng);
+            Assert.That(result, Is.EqualTo(15));
+        }
+
+        [Test]
+        public void DoubleBangCompound_EvaluatesAsCompoundOnMaxFace()
+        {
+            // 2d6!!: first die compounds 6 -> 6 -> 3 = 15, second die 4; total 19 (same as "2d6^=6")
+            var rng = new TestHelpers.MockRandomNumberGenerator(new List<int> { 6, 6, 3, 4 });
+            var result = "2d6!!".ParseRoll(rng);
+            Assert.That(result, Is.EqualTo(19));
+        }
+
+        [Test]
+        public void BareCaretCompound_EvaluatesAsCompoundOnMaxFace()
+        {
+            var rng = new TestHelpers.MockRandomNumberGenerator(new List<int> { 6, 5, 4 });
+            var result = "1d6^".ParseRoll(rng);
+            Assert.That(result, Is.EqualTo(11)); // 6 compounds -> 5 (stops), total 11
+        }
+
+        [Test]
+        public void RerollShorthand_EvaluatesLikeExplicitEquality()
+        {
+            // 4d6ro1: the 1 is rerolled once -> 5; total 5+4+6+3 = 18
+            var rng = new TestHelpers.MockRandomNumberGenerator(new List<int> { 1, 4, 6, 3, 5 });
+            var result = "4d6ro1".ParseRoll(rng);
+            Assert.That(result, Is.EqualTo(18));
+        }
+
+        [Test]
+        public void ShorthandAndExplicitForms_ProduceSameResults()
+        {
+            var pairs = new (string shorthand, string explicitForm)[]
+            {
+                ("3d6!", "3d6!=6"),
+                ("2d6!!", "2d6^=6"),
+                ("2d6^", "2d6^=6"),
+                ("4d6ro1", "4d6ro=1"),
+                ("4d6rc2", "4d6rc=2"),
+                ("2d10!10", "2d10!=10"),
+            };
+
+            foreach (var (shorthand, explicitForm) in pairs)
+            {
+                for (int seed = 0; seed < 10; seed++)
+                {
+                    var shorthandResult = shorthand.ParseRoll(new RandomIntGenerator(seed));
+                    var explicitResult = explicitForm.ParseRoll(new RandomIntGenerator(seed));
+
+                    Assert.That(shorthandResult, Is.EqualTo(explicitResult),
+                        $"'{shorthand}' and '{explicitForm}' (seed {seed}) must be equivalent");
+                }
+            }
+        }
+
+        [Test]
+        public void BareExplodeWithArithmetic_DoesNotConsumeConstantTerm()
+        {
+            // 2d6!+3: 6 explodes -> 4; total 6+2+4+3 = 15
+            var rng = new TestHelpers.MockRandomNumberGenerator(new List<int> { 6, 2, 4 });
+            var result = "2d6!+3".ParseRoll(rng);
+            Assert.That(result, Is.EqualTo(15));
+        }
+
+        #endregion
+
+        #region Parse error diagnostics
+
+        [Test]
+        public void ParseRoll_InvalidInput_ExceptionCarriesDiagnostic()
+        {
+            var ex = Assert.Throws<FormatException>(() => "2d6xx".ParseRoll());
+            Assert.That(ex.Message, Does.StartWith("Invalid roll format."));
+            Assert.That(ex.Message.Length, Is.GreaterThan("Invalid roll format.".Length),
+                "The exception message should include the parser diagnostic");
+        }
+
+        [Test]
+        public void ParseRollDetailed_InvalidInput_ExceptionCarriesDiagnostic()
+        {
+            var ex = Assert.Throws<FormatException>(() => "d6+".ParseRollDetailed());
+            Assert.That(ex.Message, Does.StartWith("Invalid roll format."));
+        }
+
+        #endregion
+    }
+}

--- a/DotDiceTests/src/Evaluator/DiceEvaluationResultTests.cs
+++ b/DotDiceTests/src/Evaluator/DiceEvaluationResultTests.cs
@@ -19,18 +19,18 @@ namespace DotDice.Tests
             var result = evaluator.EvaluateDetailed(basicRoll);
 
             // Assert
-            Assert.AreEqual(8, result.Value);
-            Assert.AreEqual(2, result.Events.Count);
+            Assert.That(result.Value, Is.EqualTo(8));
+            Assert.That(result.Events.Count, Is.EqualTo(2));
             
-            Assert.AreEqual(3, result.Events[0].Value);
-            Assert.AreEqual(DieEventType.Initial, result.Events[0].Type);
-            Assert.AreEqual(DieStatus.Kept, result.Events[0].Status);
-            Assert.AreEqual(RollSignificance.None, result.Events[0].Significance);
+            Assert.That(result.Events[0].Value, Is.EqualTo(3));
+            Assert.That(result.Events[0].Type, Is.EqualTo(DieEventType.Initial));
+            Assert.That(result.Events[0].Status, Is.EqualTo(DieStatus.Kept));
+            Assert.That(result.Events[0].Significance, Is.EqualTo(RollSignificance.None));
             
-            Assert.AreEqual(5, result.Events[1].Value);
-            Assert.AreEqual(DieEventType.Initial, result.Events[1].Type);
-            Assert.AreEqual(DieStatus.Kept, result.Events[1].Status);
-            Assert.AreEqual(RollSignificance.None, result.Events[1].Significance);
+            Assert.That(result.Events[1].Value, Is.EqualTo(5));
+            Assert.That(result.Events[1].Type, Is.EqualTo(DieEventType.Initial));
+            Assert.That(result.Events[1].Status, Is.EqualTo(DieStatus.Kept));
+            Assert.That(result.Events[1].Significance, Is.EqualTo(RollSignificance.None));
         }
 
         [Test]
@@ -44,14 +44,14 @@ namespace DotDice.Tests
             var result = evaluator.EvaluateDetailed(basicRoll);
 
             // Assert
-            Assert.AreEqual(7, result.Value);
-            Assert.AreEqual(2, result.Events.Count);
+            Assert.That(result.Value, Is.EqualTo(7));
+            Assert.That(result.Events.Count, Is.EqualTo(2));
             
-            Assert.AreEqual(1, result.Events[0].Value);
-            Assert.AreEqual(RollSignificance.Minimum, result.Events[0].Significance);
+            Assert.That(result.Events[0].Value, Is.EqualTo(1));
+            Assert.That(result.Events[0].Significance, Is.EqualTo(RollSignificance.Minimum));
             
-            Assert.AreEqual(6, result.Events[1].Value);
-            Assert.AreEqual(RollSignificance.Maximum, result.Events[1].Significance);
+            Assert.That(result.Events[1].Value, Is.EqualTo(6));
+            Assert.That(result.Events[1].Significance, Is.EqualTo(RollSignificance.Maximum));
         }
 
         [Test]
@@ -66,17 +66,17 @@ namespace DotDice.Tests
             var result = evaluator.EvaluateDetailed(basicRoll);
 
             // Assert
-            Assert.AreEqual(10, result.Value); // 4 + 6
-            Assert.AreEqual(3, result.Events.Count);
+            Assert.That(result.Value, Is.EqualTo(10)); // 4 + 6
+            Assert.That(result.Events.Count, Is.EqualTo(3));
             
             // The lowest die (2) should be dropped
             var droppedEvent = result.Events.FirstOrDefault(e => e.Value == 2);
             Assert.IsNotNull(droppedEvent);
-            Assert.AreEqual(DieStatus.Dropped, droppedEvent.Status);
+            Assert.That(droppedEvent.Status, Is.EqualTo(DieStatus.Dropped));
             
             // The highest dice (4, 6) should be kept
             var keptEvents = result.Events.Where(e => e.Status == DieStatus.Kept).ToList();
-            Assert.AreEqual(2, keptEvents.Count);
+            Assert.That(keptEvents.Count, Is.EqualTo(2));
             Assert.IsTrue(keptEvents.Any(e => e.Value == 4));
             Assert.IsTrue(keptEvents.Any(e => e.Value == 6));
         }
@@ -93,23 +93,23 @@ namespace DotDice.Tests
             var result = evaluator.EvaluateDetailed(basicRoll);
 
             // Assert
-            Assert.AreEqual(7, result.Value); // 4 + 3
-            Assert.AreEqual(3, result.Events.Count);
+            Assert.That(result.Value, Is.EqualTo(7)); // 4 + 3
+            Assert.That(result.Events.Count, Is.EqualTo(3));
             
             // First event should be the original 1, now discarded
-            Assert.AreEqual(1, result.Events[0].Value);
-            Assert.AreEqual(DieEventType.Initial, result.Events[0].Type);
-            Assert.AreEqual(DieStatus.Discarded, result.Events[0].Status);
+            Assert.That(result.Events[0].Value, Is.EqualTo(1));
+            Assert.That(result.Events[0].Type, Is.EqualTo(DieEventType.Initial));
+            Assert.That(result.Events[0].Status, Is.EqualTo(DieStatus.Discarded));
             
             // Second event should be the 3, kept
-            Assert.AreEqual(3, result.Events[1].Value);
-            Assert.AreEqual(DieEventType.Initial, result.Events[1].Type);
-            Assert.AreEqual(DieStatus.Kept, result.Events[1].Status);
+            Assert.That(result.Events[1].Value, Is.EqualTo(3));
+            Assert.That(result.Events[1].Type, Is.EqualTo(DieEventType.Initial));
+            Assert.That(result.Events[1].Status, Is.EqualTo(DieStatus.Kept));
             
             // Third event should be the reroll to 4
-            Assert.AreEqual(4, result.Events[2].Value);
-            Assert.AreEqual(DieEventType.Reroll, result.Events[2].Type);
-            Assert.AreEqual(DieStatus.Kept, result.Events[2].Status);
+            Assert.That(result.Events[2].Value, Is.EqualTo(4));
+            Assert.That(result.Events[2].Type, Is.EqualTo(DieEventType.Reroll));
+            Assert.That(result.Events[2].Status, Is.EqualTo(DieStatus.Kept));
         }
 
         [Test]
@@ -124,23 +124,23 @@ namespace DotDice.Tests
             var result = evaluator.EvaluateDetailed(basicRoll);
 
             // Assert
-            Assert.AreEqual(14, result.Value); // 6 + 3 + 5
-            Assert.AreEqual(3, result.Events.Count);
+            Assert.That(result.Value, Is.EqualTo(14)); // 6 + 3 + 5
+            Assert.That(result.Events.Count, Is.EqualTo(3));
             
             // First event: original 6
-            Assert.AreEqual(6, result.Events[0].Value);
-            Assert.AreEqual(DieEventType.Initial, result.Events[0].Type);
-            Assert.AreEqual(DieStatus.Kept, result.Events[0].Status);
+            Assert.That(result.Events[0].Value, Is.EqualTo(6));
+            Assert.That(result.Events[0].Type, Is.EqualTo(DieEventType.Initial));
+            Assert.That(result.Events[0].Status, Is.EqualTo(DieStatus.Kept));
             
             // Second event: original 3
-            Assert.AreEqual(3, result.Events[1].Value);
-            Assert.AreEqual(DieEventType.Initial, result.Events[1].Type);
-            Assert.AreEqual(DieStatus.Kept, result.Events[1].Status);
+            Assert.That(result.Events[1].Value, Is.EqualTo(3));
+            Assert.That(result.Events[1].Type, Is.EqualTo(DieEventType.Initial));
+            Assert.That(result.Events[1].Status, Is.EqualTo(DieStatus.Kept));
             
             // Third event: explosion from the 6
-            Assert.AreEqual(5, result.Events[2].Value);
-            Assert.AreEqual(DieEventType.Explosion, result.Events[2].Type);
-            Assert.AreEqual(DieStatus.Kept, result.Events[2].Status);
+            Assert.That(result.Events[2].Value, Is.EqualTo(5));
+            Assert.That(result.Events[2].Type, Is.EqualTo(DieEventType.Explosion));
+            Assert.That(result.Events[2].Status, Is.EqualTo(DieStatus.Kept));
         }
 
         [Test]
@@ -154,8 +154,8 @@ namespace DotDice.Tests
             var result = evaluator.EvaluateDetailed(constant);
 
             // Assert
-            Assert.AreEqual(5, result.Value);
-            Assert.AreEqual(0, result.Events.Count);
+            Assert.That(result.Value, Is.EqualTo(5));
+            Assert.That(result.Events.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -170,17 +170,17 @@ namespace DotDice.Tests
             var result = evaluator.EvaluateDetailed(basicRoll);
 
             // Assert
-            Assert.AreEqual(7, result.Value); // 4 + 3
-            Assert.AreEqual(2, result.Events.Count);
+            Assert.That(result.Value, Is.EqualTo(7)); // 4 + 3
+            Assert.That(result.Events.Count, Is.EqualTo(2));
             
             // First event: the die roll
-            Assert.AreEqual(4, result.Events[0].Value);
-            Assert.AreEqual(DieEventType.Initial, result.Events[0].Type);
+            Assert.That(result.Events[0].Value, Is.EqualTo(4));
+            Assert.That(result.Events[0].Type, Is.EqualTo(DieEventType.Initial));
             
             // Second event: the constant
-            Assert.AreEqual(3, result.Events[1].Value);
-            Assert.AreEqual(DieEventType.Initial, result.Events[1].Type);
-            Assert.AreEqual(DieStatus.Kept, result.Events[1].Status);
+            Assert.That(result.Events[1].Value, Is.EqualTo(3));
+            Assert.That(result.Events[1].Type, Is.EqualTo(DieEventType.Initial));
+            Assert.That(result.Events[1].Status, Is.EqualTo(DieStatus.Kept));
         }
     }
 }

--- a/DotDiceTests/src/Evaluator/DiceEvaluatorTests.cs
+++ b/DotDiceTests/src/Evaluator/DiceEvaluatorTests.cs
@@ -123,7 +123,7 @@ namespace DotDice.Tests
         {
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var basicRoll = new BasicRoll(numberOfDice, new DieType.Percent(), new List<Modifier>());
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll));
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected));
         }
 
         public static IEnumerable<TestCaseData> Evaluate_PercentRoll_ReturnsSumOfDice_TestCases()
@@ -141,7 +141,7 @@ namespace DotDice.Tests
         {
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var basicRoll = new BasicRoll(numberOfDice, new DieType.Fudge(), new List<Modifier>());
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll));
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected));
         }
 
         public static IEnumerable<TestCaseData> Evaluate_FudgeRoll_ReturnsSumOfDice_TestCases()
@@ -161,7 +161,7 @@ namespace DotDice.Tests
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var modifiers = new List<Modifier> { new KeepModifier(keepCount, true) };
             var basicRoll = new BasicRoll(numberOfDice, dieType, modifiers);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll));
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected));
         }
 
         public static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithKeepHighestModifier_TestCases()
@@ -192,7 +192,7 @@ namespace DotDice.Tests
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var modifiers = new List<Modifier> { new KeepModifier(keepCount, false) };
             var basicRoll = new BasicRoll(numberOfDice, dieType, modifiers);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll));
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected));
         }
 
         public static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithKeepLowestModifier_TestCases()
@@ -223,7 +223,7 @@ namespace DotDice.Tests
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var modifiers = new List<Modifier> { new DropModifier(dropCount, true) };
             var basicRoll = new BasicRoll(numberOfDice, dieType, modifiers);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll));
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected));
         }
 
         public static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithDropHighestModifier_TestCases()
@@ -254,7 +254,7 @@ namespace DotDice.Tests
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var modifiers = new List<Modifier> { new DropModifier(dropCount, false) };
             var basicRoll = new BasicRoll(numberOfDice, dieType, modifiers);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll));
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected));
         }
 
         public static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithDropLowestModifier_TestCases()
@@ -285,7 +285,7 @@ namespace DotDice.Tests
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var modifiers = new List<Modifier> { new KeepModifier(keepCount, true) };
             var basicRoll = new BasicRoll(numberOfDice, new DieType.Basic(12), modifiers);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll), description);
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected), description);
         }
 
         public static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithKeepHighest_DuplicateValues_TestCases()
@@ -329,7 +329,7 @@ namespace DotDice.Tests
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var modifiers = new List<Modifier> { new KeepModifier(keepCount, false) };
             var basicRoll = new BasicRoll(numberOfDice, new DieType.Basic(12), modifiers);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll), description);
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected), description);
         }
 
         public static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithKeepLowest_DuplicateValues_TestCases()
@@ -373,7 +373,7 @@ namespace DotDice.Tests
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var modifiers = new List<Modifier> { new DropModifier(dropCount, true) };
             var basicRoll = new BasicRoll(numberOfDice, new DieType.Basic(12), modifiers);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll), description);
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected), description);
         }
 
         public static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithDropHighest_DuplicateValues_TestCases()
@@ -417,7 +417,7 @@ namespace DotDice.Tests
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var modifiers = new List<Modifier> { new DropModifier(dropCount, false) };
             var basicRoll = new BasicRoll(numberOfDice, new DieType.Basic(12), modifiers);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll), description);
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected), description);
         }
 
         public static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithDropLowest_DuplicateValues_TestCases()
@@ -461,7 +461,7 @@ namespace DotDice.Tests
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var modifiers = new List<Modifier> { new RerollOnceModifier(comparisonOperator, value) };
             var basicRoll = new BasicRoll(numberOfDice, dieType, modifiers);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll));
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected));
         }
 
         public static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithRerollOnceModifier_TestCases()
@@ -487,7 +487,7 @@ namespace DotDice.Tests
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var modifiers = new List<Modifier> { new RerollMultipleModifier(comparisonOperator, value) };
             var basicRoll = new BasicRoll(numberOfDice, dieType, modifiers);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll));
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected));
         }
 
         public static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithRerollMultipleModifier_TestCases()
@@ -521,7 +521,7 @@ namespace DotDice.Tests
             var evaluator = new DiceEvaluator(rng);
             var modifiers = new List<Modifier> { new ExplodeModifier(comparisonOperator, value) };
             var basicRoll = new BasicRoll(numberOfDice, dieType, modifiers);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll));
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected));
         }
 
         private static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithExplodeModifier_TestCases()
@@ -555,7 +555,7 @@ namespace DotDice.Tests
             var evaluator = new DiceEvaluator(rng);
             var modifiers = new List<Modifier> { new CompoundingModifier(comparisonOperator, value) };
             var basicRoll = new BasicRoll(numberOfDice, dieType, modifiers);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll));
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected));
         }
 
         public static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithCompoundingModifier_TestCases()
@@ -589,7 +589,7 @@ namespace DotDice.Tests
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var modifiers = new List<Modifier> { new SuccessModifier(comparisonOperator, value) };
             var basicRoll = new BasicRoll(numberOfDice, dieType, modifiers);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll));
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected));
         }
 
         public static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithSuccessModifier_TestCases()
@@ -632,7 +632,7 @@ namespace DotDice.Tests
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var modifiers = new List<Modifier> { new FailureModifier(comparisonOperator, value) };
             var basicRoll = new BasicRoll(numberOfDice, dieType, modifiers);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll));
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected));
         }
 
         public static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithFailureModifier_TestCases()
@@ -671,7 +671,7 @@ namespace DotDice.Tests
         {
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var basicRoll = new BasicRoll(numbers.Count, new DieType.Basic(6), mods);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll));
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected));
         }
 
         public static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithConstantModifier_TestCases()
@@ -687,7 +687,7 @@ namespace DotDice.Tests
             var evaluator = new DiceEvaluator(new TestHelpers.MockRandomNumberGenerator(numbers));
             var modifiers = mods;
             var basicRoll = new BasicRoll(numbers.Count, new DieType.Basic(6), modifiers);
-            Assert.AreEqual(expected, evaluator.Evaluate(basicRoll));
+            Assert.That(evaluator.Evaluate(basicRoll), Is.EqualTo(expected));
         }
 
         public static IEnumerable<TestCaseData> Evaluate_BasicRoll_WithConstantModifierAndAnotherModifier_TestCases()
@@ -771,7 +771,7 @@ namespace DotDice.Tests
         public void Evaluate_RealWorldScenarios_CalculatesCorrectly(IRandomNumberGenerator<int> rng, Roll roll, int expected, string scenarioDescription)
         {
             var evaluator = new DiceEvaluator(rng);
-            Assert.AreEqual(expected, evaluator.Evaluate(roll), $"Failed scenario: {scenarioDescription}");
+            Assert.That(evaluator.Evaluate(roll), Is.EqualTo(expected), $"Failed scenario: {scenarioDescription}");
         }
 
         public static IEnumerable<TestCaseData> Evaluate_RealWorldScenarios_TestCases()
@@ -857,16 +857,18 @@ namespace DotDice.Tests
                 "FATE/Fudge: 4dF+2 (1,-1,0,1+2) = 3"
             );
 
-            // Complex Attack Roll: 2d20 advantage, keep highest, add 5, crit on 20
+            // Complex Attack Roll: 2d20 advantage, keep highest, add 5, crit on 20.
+            // Phase model: explosions are generated first (20 explodes into a new 6),
+            // then kh1 keeps the single highest die of the whole pool (20), then +5.
             yield return new TestCaseData(
                 new TestHelpers.MockRandomNumberGenerator(new List<int> { 20, 12, 6 }),
-                new BasicRoll(2, new DieType.Basic(20), new List<Modifier> { 
+                new BasicRoll(2, new DieType.Basic(20), new List<Modifier> {
                     new KeepModifier(1, true),
                     new ExplodeModifier(ComparisonOperator.Equal, 20),
                     new ConstantModifier(ArithmeticOperator.Add, 5)
                 }),
-                31, // 20 (first roll) + 6 (explosion) + 5 (modifier) = 31
-                "Complex Attack: 1d20 advantage, explode on 20, +5 modifier (20->6, 5) = 31"
+                25, // kh1 keeps the 20; the 12 and the exploded 6 are dropped; +5 = 25
+                "Complex Attack: 2d20kh1 exploding on 20, +5 modifier (20,12, explode 6; keep 20) = 25"
             );
 
             // Call of Cthulhu: d100 check against skill of 50, lower is better
@@ -930,7 +932,7 @@ namespace DotDice.Tests
             int combinedResult = resultCombiner(results);
             
             // Assert the combined result matches the expected value
-            Assert.AreEqual(expected, combinedResult, description);
+            Assert.That(combinedResult, Is.EqualTo(expected), description);
         }
         
         public static IEnumerable<TestCaseData> Evaluate_MultipleRoll_Scenarios_TestCases()

--- a/DotDiceTests/src/Extension/StringExtensionsDetailedTests.cs
+++ b/DotDiceTests/src/Extension/StringExtensionsDetailedTests.cs
@@ -20,10 +20,10 @@ namespace DotDice.Tests
             var result = "2d6".ParseRollDetailed(rng);
 
             // Assert
-            Assert.AreEqual(6, result.Value);
-            Assert.AreEqual(2, result.Events.Count);
-            Assert.AreEqual(4, result.Events[0].Value);
-            Assert.AreEqual(2, result.Events[1].Value);
+            Assert.That(result.Value, Is.EqualTo(6));
+            Assert.That(result.Events.Count, Is.EqualTo(2));
+            Assert.That(result.Events[0].Value, Is.EqualTo(4));
+            Assert.That(result.Events[1].Value, Is.EqualTo(2));
             Assert.IsTrue(result.Events.All(e => e.Type == DieEventType.Initial));
             Assert.IsTrue(result.Events.All(e => e.Status == DieStatus.Kept));
         }
@@ -38,20 +38,20 @@ namespace DotDice.Tests
             var result = "2d6ro<2".ParseRollDetailed(rng);
 
             // Assert
-            Assert.AreEqual(8, result.Value); // 3 + 5
-            Assert.AreEqual(3, result.Events.Count);
+            Assert.That(result.Value, Is.EqualTo(8)); // 3 + 5
+            Assert.That(result.Events.Count, Is.EqualTo(3));
             
             // Original 1 (discarded)
-            Assert.AreEqual(1, result.Events[0].Value);
-            Assert.AreEqual(DieStatus.Discarded, result.Events[0].Status);
+            Assert.That(result.Events[0].Value, Is.EqualTo(1));
+            Assert.That(result.Events[0].Status, Is.EqualTo(DieStatus.Discarded));
             
             // Original 5 (kept)
-            Assert.AreEqual(5, result.Events[1].Value);
-            Assert.AreEqual(DieStatus.Kept, result.Events[1].Status);
+            Assert.That(result.Events[1].Value, Is.EqualTo(5));
+            Assert.That(result.Events[1].Status, Is.EqualTo(DieStatus.Kept));
             
             // Reroll to 3
-            Assert.AreEqual(3, result.Events[2].Value);
-            Assert.AreEqual(DieEventType.Reroll, result.Events[2].Type);
+            Assert.That(result.Events[2].Value, Is.EqualTo(3));
+            Assert.That(result.Events[2].Type, Is.EqualTo(DieEventType.Reroll));
         }
 
         [Test]
@@ -64,21 +64,21 @@ namespace DotDice.Tests
             var result = "2d6!=6".ParseRollDetailed(rng);
 
             // Assert
-            Assert.AreEqual(13, result.Value); // 6 + 4 + 3
-            Assert.AreEqual(3, result.Events.Count);
+            Assert.That(result.Value, Is.EqualTo(13)); // 6 + 4 + 3
+            Assert.That(result.Events.Count, Is.EqualTo(3));
             
             // Original 6
-            Assert.AreEqual(6, result.Events[0].Value);
-            Assert.AreEqual(DieEventType.Initial, result.Events[0].Type);
-            Assert.AreEqual(RollSignificance.Maximum, result.Events[0].Significance);
+            Assert.That(result.Events[0].Value, Is.EqualTo(6));
+            Assert.That(result.Events[0].Type, Is.EqualTo(DieEventType.Initial));
+            Assert.That(result.Events[0].Significance, Is.EqualTo(RollSignificance.Maximum));
             
             // Original 4
-            Assert.AreEqual(4, result.Events[1].Value);
-            Assert.AreEqual(DieEventType.Initial, result.Events[1].Type);
+            Assert.That(result.Events[1].Value, Is.EqualTo(4));
+            Assert.That(result.Events[1].Type, Is.EqualTo(DieEventType.Initial));
             
             // Explosion from first die
-            Assert.AreEqual(3, result.Events[2].Value);
-            Assert.AreEqual(DieEventType.Explosion, result.Events[2].Type);
+            Assert.That(result.Events[2].Value, Is.EqualTo(3));
+            Assert.That(result.Events[2].Type, Is.EqualTo(DieEventType.Explosion));
         }
 
         [Test]
@@ -91,17 +91,17 @@ namespace DotDice.Tests
             var result = "3d6kh2".ParseRollDetailed(rng);
 
             // Assert
-            Assert.AreEqual(10, result.Value); // 6 + 4 (2 is dropped)
-            Assert.AreEqual(3, result.Events.Count);
+            Assert.That(result.Value, Is.EqualTo(10)); // 6 + 4 (2 is dropped)
+            Assert.That(result.Events.Count, Is.EqualTo(3));
             
             // Check that the lowest die (2) is dropped
             var droppedEvent = result.Events.FirstOrDefault(e => e.Value == 2);
             Assert.IsNotNull(droppedEvent);
-            Assert.AreEqual(DieStatus.Dropped, droppedEvent.Status);
+            Assert.That(droppedEvent.Status, Is.EqualTo(DieStatus.Dropped));
             
             // Check that the highest dice are kept
             var keptEvents = result.Events.Where(e => e.Status == DieStatus.Kept).ToList();
-            Assert.AreEqual(2, keptEvents.Count);
+            Assert.That(keptEvents.Count, Is.EqualTo(2));
             Assert.IsTrue(keptEvents.Any(e => e.Value == 6));
             Assert.IsTrue(keptEvents.Any(e => e.Value == 4));
         }
@@ -113,8 +113,8 @@ namespace DotDice.Tests
             var result = "5".ParseRollDetailed();
 
             // Assert
-            Assert.AreEqual(5, result.Value);
-            Assert.AreEqual(0, result.Events.Count);
+            Assert.That(result.Value, Is.EqualTo(5));
+            Assert.That(result.Events.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -127,16 +127,16 @@ namespace DotDice.Tests
             var result = "1d6+3".ParseRollDetailed(rng);
 
             // Assert
-            Assert.AreEqual(7, result.Value);
-            Assert.AreEqual(2, result.Events.Count);
+            Assert.That(result.Value, Is.EqualTo(7));
+            Assert.That(result.Events.Count, Is.EqualTo(2));
             
             // Dice roll
-            Assert.AreEqual(4, result.Events[0].Value);
-            Assert.AreEqual(DieEventType.Initial, result.Events[0].Type);
+            Assert.That(result.Events[0].Value, Is.EqualTo(4));
+            Assert.That(result.Events[0].Type, Is.EqualTo(DieEventType.Initial));
             
             // Constant
-            Assert.AreEqual(3, result.Events[1].Value);
-            Assert.AreEqual(DieEventType.Initial, result.Events[1].Type);
+            Assert.That(result.Events[1].Value, Is.EqualTo(3));
+            Assert.That(result.Events[1].Type, Is.EqualTo(DieEventType.Initial));
         }
 
         [Test]

--- a/DotDiceTests/src/Extension/StringExtensionsTests.cs
+++ b/DotDiceTests/src/Extension/StringExtensionsTests.cs
@@ -40,7 +40,7 @@ namespace DotDice.Tests
         {
             var mockRng = new TestHelpers.MockRandomNumberGenerator(randomValues);
             int result = input.ParseRoll(mockRng);
-            Assert.AreEqual(expectedResult, result, $"Roll result should be {expectedResult}");
+            Assert.That(result, Is.EqualTo(expectedResult), $"Roll result should be {expectedResult}");
         }
 
         public static IEnumerable<TestCaseData> ParseRoll_ModifiedRolls_TestCases()
@@ -83,7 +83,7 @@ namespace DotDice.Tests
         {
             var mockRng = new TestHelpers.MockRandomNumberGenerator(randomValues);
             int result = input.ParseRoll(mockRng);
-            Assert.AreEqual(expectedResult, result, $"Roll result should be {expectedResult}");
+            Assert.That(result, Is.EqualTo(expectedResult), $"Roll result should be {expectedResult}");
         }
 
         public static IEnumerable<TestCaseData> ParseRoll_ComplexNotations_TestCases()
@@ -139,10 +139,10 @@ namespace DotDice.Tests
             int result4 = " 1d6 ".ParseRoll(mockRng);
             
             // All should have the same result
-            Assert.AreEqual(4, result1);
-            Assert.AreEqual(4, result2);
-            Assert.AreEqual(4, result3);
-            Assert.AreEqual(4, result4);
+            Assert.That(result1, Is.EqualTo(4));
+            Assert.That(result2, Is.EqualTo(4));
+            Assert.That(result3, Is.EqualTo(4));
+            Assert.That(result4, Is.EqualTo(4));
         }
 
         #endregion
@@ -155,7 +155,7 @@ namespace DotDice.Tests
         {
             var mockRng = new TestHelpers.MockRandomNumberGenerator(randomValues);
             int result = input.ParseRoll(mockRng);
-            Assert.AreEqual(expectedResult, result, $"{description}: Roll result should be {expectedResult}");
+            Assert.That(result, Is.EqualTo(expectedResult), $"{description}: Roll result should be {expectedResult}");
         }
 
         public static IEnumerable<TestCaseData> ParseRoll_RealWorldScenarios_TestCases()
@@ -190,16 +190,16 @@ namespace DotDice.Tests
             
             // Test with exploding dice (should hit the explosion limit)
             int result1 = "1d6!=6".ParseRoll(repeatingRng);
-            Assert.AreEqual(606, result1, "Exploding dice should hit the explosion limit");
+            Assert.That(result1, Is.EqualTo(606), "Exploding dice should hit the explosion limit");
             
             // Test with compound dice (should hit the compound limit)
             int result2 = "1d6^=6".ParseRoll(repeatingRng);
-            Assert.AreEqual(606, result2, "Compounding dice should hit the compound limit");
+            Assert.That(result2, Is.EqualTo(606), "Compounding dice should hit the compound limit");
             
             // Test with success counting
             var repeatingRng3 = new RepeatingRandomNumberGenerator(5);
             int result3 = "10d6>4".ParseRoll(repeatingRng3);
-            Assert.AreEqual(10, result3, "All dice should succeed");
+            Assert.That(result3, Is.EqualTo(10), "All dice should succeed");
         }
 
         #endregion
@@ -212,7 +212,7 @@ namespace DotDice.Tests
         {
             var mockRng = new TestHelpers.MockRandomNumberGenerator(randomValues);
             int result = input.ParseRoll(mockRng);
-            Assert.AreEqual(expectedResult, result, $"Arithmetic roll result should be {expectedResult}");
+            Assert.That(result, Is.EqualTo(expectedResult), $"Arithmetic roll result should be {expectedResult}");
         }
 
         public static IEnumerable<TestCaseData> ParseRoll_ArithmeticExpressions_TestCases()

--- a/DotDiceTests/src/Parser/DiceParserTests.cs
+++ b/DotDiceTests/src/Parser/DiceParserTests.cs
@@ -62,6 +62,8 @@ namespace DotDice.Tests
         [TestCase("!=5", ComparisonOperator.Equal, 5)]
         [TestCase("!>10", ComparisonOperator.GreaterThan, 10)]
         [TestCase("!<3", ComparisonOperator.LessThan, 3)]
+        [TestCase("!5", ComparisonOperator.Equal, 5)]  // Bare integer shorthand for equality
+        [TestCase("!", ComparisonOperator.Equal, DiceParser.MaxFaceSentinel)]  // Bare "!" explodes on max face (resolved when the roll is built)
         public void ExplodeModifier_Parse_ValidInput_ShouldSucceed(string input, ComparisonOperator expectedOp, int expectedValue)
         {
             var result = DiceParser.explodeModifier.Parse(input);
@@ -72,12 +74,14 @@ namespace DotDice.Tests
             Assert.That(modifier.Value, Is.EqualTo(expectedValue));
         }
 
-        [TestCase("!5")]  // Missing operator
-        [TestCase("!>")]  // Missing value
-        public void ExplodeModifier_Parse_InvalidInput_ShouldFail(string input)
+        // "!>" (operator without value) is no longer rejected at the single-modifier level,
+        // because bare "!" is now a valid prefix; the dangling ">" must fail at the Roll level.
+        [TestCase("d6!>")]
+        [TestCase("2d6!<")]
+        public void ExplodeModifier_DanglingComparison_ShouldFailAtRollLevel(string input)
         {
-            var result = DiceParser.explodeModifier.Parse(input);
-            Assert.IsFalse(result.Success, "Parser should fail for invalid explode modifier");
+            var result = DiceParser.Roll.Parse(input);
+            Assert.IsFalse(result.Success, "Roll parser should fail for dangling comparison after '!'");
         }
 
         #endregion
@@ -87,6 +91,11 @@ namespace DotDice.Tests
         [TestCase("^=5", ComparisonOperator.Equal, 5)]
         [TestCase("^>10", ComparisonOperator.GreaterThan, 10)]
         [TestCase("^<3", ComparisonOperator.LessThan, 3)]
+        [TestCase("^5", ComparisonOperator.Equal, 5)]    // Bare integer shorthand for equality
+        [TestCase("^", ComparisonOperator.Equal, DiceParser.MaxFaceSentinel)]    // Bare "^" compounds on max face
+        [TestCase("!!", ComparisonOperator.Equal, DiceParser.MaxFaceSentinel)]   // "!!" is the common VTT alias for compounding
+        [TestCase("!!=6", ComparisonOperator.Equal, 6)]
+        [TestCase("!!6", ComparisonOperator.Equal, 6)]
         public void CompoundingModifier_Parse_ValidInput_ShouldSucceed(string input, ComparisonOperator expectedOp, int expectedValue)
         {
             var result = DiceParser.compoundingModifier.Parse(input);
@@ -97,12 +106,13 @@ namespace DotDice.Tests
             Assert.That(modifier.Value, Is.EqualTo(expectedValue));
         }
 
-        [TestCase("^5")]  // Missing operator
-        [TestCase("^>")]  // Missing value
-        public void CompoundingModifier_Parse_InvalidInput_ShouldFail(string input)
+        // "^>" (operator without value) must fail at the Roll level now that bare "^" is valid.
+        [TestCase("d6^>")]
+        [TestCase("2d6^<")]
+        public void CompoundingModifier_DanglingComparison_ShouldFailAtRollLevel(string input)
         {
-            var result = DiceParser.compoundingModifier.Parse(input);
-            Assert.IsFalse(result.Success, "Parser should fail for invalid compounding modifier");
+            var result = DiceParser.Roll.Parse(input);
+            Assert.IsFalse(result.Success, "Roll parser should fail for dangling comparison after '^'");
         }
 
         #endregion
@@ -111,6 +121,7 @@ namespace DotDice.Tests
 
         [TestCase("ro=5", ComparisonOperator.Equal, 5, true)]
         [TestCase("ro>10", ComparisonOperator.GreaterThan, 10, false)]
+        [TestCase("ro1", ComparisonOperator.Equal, 1, true)]  // Bare integer shorthand: "ro1" == "ro=1"
         public void RerollOnceModifier_Parse_ValidInput_ShouldSucceed(string input, ComparisonOperator expectedOp, int expectedValue, bool expectedOnlyOnce)
         {
             var result = DiceParser.rerollOnceModifier.Parse(input);
@@ -121,8 +132,8 @@ namespace DotDice.Tests
             Assert.That(modifier.Value, Is.EqualTo(expectedValue));
         }
 
-        [TestCase("ro5")]  // Missing operator
         [TestCase("ro>")]  // Missing value
+        [TestCase("ro")]   // Missing comparison entirely
         public void RerollOnceModifier_Parse_InvalidInput_ShouldFail(string input)
         {
             var result = DiceParser.rerollOnceModifier.Parse(input);
@@ -135,6 +146,7 @@ namespace DotDice.Tests
 
         [TestCase("rc=5", ComparisonOperator.Equal, 5)]
         [TestCase("rc>10", ComparisonOperator.GreaterThan, 10)]
+        [TestCase("rc2", ComparisonOperator.Equal, 2)]  // Bare integer shorthand: "rc2" == "rc=2"
         public void RerollCompoundModifier_Parse_ValidInput_ShouldSucceed(string input, ComparisonOperator expectedOp, int expectedValue)
         {
             var result = DiceParser.rerollCompoundModifier.Parse(input);
@@ -145,8 +157,8 @@ namespace DotDice.Tests
             Assert.That(modifier.Value, Is.EqualTo(expectedValue));
         }
 
-        [TestCase("rc5")]   // Missing operator
         [TestCase("rc>")]   // Missing value
+        [TestCase("rc")]    // Missing comparison entirely
         public void RerollCompoundModifier_Parse_InvalidInput_ShouldFail(string input)
         {
             var result = DiceParser.rerollCompoundModifier.Parse(input);
@@ -423,6 +435,86 @@ namespace DotDice.Tests
             var constMod = modifiers[5] as ConstantModifier;
             Assert.That(constMod?.Operator, Is.EqualTo(ArithmeticOperator.Subtract));
             Assert.That(constMod?.Value, Is.EqualTo(7));
+        }
+
+        #endregion
+
+        #region Shorthand Modifier Tests
+
+        // Bare "!" / "^" / "!!" resolve to the die's maximum face when the roll is built.
+        [TestCase("2d6!", typeof(ExplodeModifier), ComparisonOperator.Equal, 6)]
+        [TestCase("3d10!", typeof(ExplodeModifier), ComparisonOperator.Equal, 10)]
+        [TestCase("d%!", typeof(ExplodeModifier), ComparisonOperator.Equal, 100)]
+        [TestCase("4dF!", typeof(ExplodeModifier), ComparisonOperator.Equal, 1)]
+        [TestCase("2d6^", typeof(CompoundingModifier), ComparisonOperator.Equal, 6)]
+        [TestCase("2d6!!", typeof(CompoundingModifier), ComparisonOperator.Equal, 6)]
+        [TestCase("2d8!!", typeof(CompoundingModifier), ComparisonOperator.Equal, 8)]
+        [TestCase("3d6!6", typeof(ExplodeModifier), ComparisonOperator.Equal, 6)]
+        [TestCase("3d6!2", typeof(ExplodeModifier), ComparisonOperator.Equal, 2)]
+        [TestCase("4d6ro1", typeof(RerollOnceModifier), ComparisonOperator.Equal, 1)]
+        [TestCase("4d6rc2", typeof(RerollMultipleModifier), ComparisonOperator.Equal, 2)]
+        public void Roll_Parse_ShorthandModifiers_ResolveCorrectly(string input, Type expectedModifierType, ComparisonOperator expectedOp, int expectedValue)
+        {
+            var result = DiceParser.Roll.Parse(input);
+            Assert.IsTrue(result.Success, $"Roll parser should succeed for shorthand input '{input}'");
+
+            var roll = result.Value as BasicRoll;
+            Assert.NotNull(roll);
+
+            var modifiers = roll.Modifiers.ToList();
+            Assert.That(modifiers.Count, Is.EqualTo(1));
+            Assert.That(modifiers[0], Is.TypeOf(expectedModifierType));
+
+            var (op, value) = modifiers[0] switch
+            {
+                ExplodeModifier em => (em.Operator, em.Value),
+                CompoundingModifier cm => (cm.Operator, cm.Value),
+                RerollOnceModifier rom => (rom.Operator, rom.Value),
+                RerollMultipleModifier rmm => (rmm.Operator, rmm.Value),
+                _ => throw new InvalidOperationException("Unexpected modifier type")
+            };
+
+            Assert.That(op, Is.EqualTo(expectedOp));
+            Assert.That(value, Is.EqualTo(expectedValue), "Sentinel should be resolved to the die's max face");
+        }
+
+        [Test]
+        public void Roll_Parse_BareExplodeFollowedByArithmetic_ParsesAsArithmeticRoll()
+        {
+            // The bare-integer shorthand must not consume the "+3" term
+            var result = DiceParser.Roll.Parse("2d6!+3");
+            Assert.IsTrue(result.Success, "Roll parser should succeed for '2d6!+3'");
+
+            var arithmeticRoll = result.Value as ArithmeticRoll;
+            Assert.NotNull(arithmeticRoll, "'2d6!+3' should parse as an arithmetic roll");
+            Assert.That(arithmeticRoll.Terms.Count, Is.EqualTo(2));
+
+            var firstRoll = arithmeticRoll.Terms[0].Roll as BasicRoll;
+            Assert.NotNull(firstRoll);
+            var explode = firstRoll.Modifiers.Single() as ExplodeModifier;
+            Assert.NotNull(explode);
+            Assert.That(explode.Value, Is.EqualTo(6), "Bare '!' should explode on the max face, not consume '+3'");
+
+            var constant = arithmeticRoll.Terms[1].Roll as Constant;
+            Assert.NotNull(constant);
+            Assert.That(constant.Value, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void Roll_Parse_ShorthandWithOtherModifiers_ParsesCorrectly()
+        {
+            // Shorthand explode mixed with keep: "3d6!kh2"
+            var result = DiceParser.Roll.Parse("3d6!kh2");
+            Assert.IsTrue(result.Success);
+
+            var roll = result.Value as BasicRoll;
+            Assert.NotNull(roll);
+
+            var modifiers = roll.Modifiers.ToList();
+            Assert.That(modifiers.Count, Is.EqualTo(2));
+            Assert.IsTrue(modifiers[0] is ExplodeModifier);
+            Assert.IsTrue(modifiers[1] is KeepModifier);
+            Assert.That(((ExplodeModifier)modifiers[0]).Value, Is.EqualTo(6));
         }
 
         #endregion

--- a/grammar
+++ b/grammar
@@ -1,16 +1,19 @@
-<roll>              ::= <basic_roll> | <constant>
+<roll>              ::= <arithmetic_roll> | <basic_roll> | <constant>
 
-<basic_roll>        ::= <number_of_dice> "d" <die_type_section> <modifiers> 
+<arithmetic_roll>   ::= <roll_term> (<arithmetic_op> <roll_term>)+
 
-<arithmetic>        ::= <addition>
-                      | <subtraction>
+<roll_term>         ::= <basic_roll> | <constant> // basic_roll here excludes <constant_modifier>; trailing +N/-N parse as arithmetic terms
 
-<constant>          ::= <integer>
+<arithmetic_op>     ::= "+" | "-"
 
-<number_of_dice>    ::= <integer>
+<basic_roll>        ::= <number_of_dice> "d" <die_type_section> <modifiers>
+
+<constant>          ::= <positive_integer>
+
+<number_of_dice>    ::= <positive_integer>
                       | ""  // Empty string represents 1 die
 
-<die_type_section>  ::= <integer>
+<die_type_section>  ::= <positive_integer>
                       | "%"
                       | "F"
 
@@ -19,12 +22,11 @@
 <modifier>          ::= <keep_modifier>
                       | <drop_modifier>
                       | <reroll_modifier>
+                      | <compounding_modifier> // tried before explode so "!!" is a compound
                       | <explode_modifier>
-                      | <compounding_modifier>
                       | <success_modifier>
                       | <failure_modifier>
-                      | <sort_modifier>
-                      | <contstant_modifier>
+                      | <constant_modifier>
 
 <keep_modifier>     ::= "kl" <keep_drop_value> //keep keep_drop_value lowest results
                       | "kh" <keep_drop_value> //keep keep_drop_value highest results
@@ -32,26 +34,29 @@
 <drop_modifier>     ::= "dl" <keep_drop_value> //drop keep_drop_value lowest results
                       | "dh" <keep_drop_value> //drop keep_drop_value highest results
 
-<keep_drop_value>   ::= <integer>
-                      | "" //Empty string indicates default behavior
+<keep_drop_value>   ::= <positive_integer>
+                      | "" //Empty string defaults to 1
 
-<reroll_modifier>   ::= "rc" <comparison_point> // continuesly re-roll any result that meets comparison_point
-                      | "ro" <comparison_point> // re-roll once any result that meets comparison_point
+<reroll_modifier>   ::= "rc" <comparison_or_value> // continuously re-roll any result that meets the comparison
+                      | "ro" <comparison_or_value> // re-roll once any result that meets the comparison
 
-<explode_modifier>  ::= "!" <comparison_point> // add an additional dice role for every comparison_point result
+<explode_modifier>  ::= "!" <comparison_or_value>? // add an additional die roll for every matching result; bare "!" explodes on the die's maximum face
 
-<compounding_modifier> ::= "^" <comparison_point> //if comparison_point is met, then roll another dice and add it to the total. This new roll can compound also.
+<compounding_modifier> ::= ("^" | "!!") <comparison_or_value>? // like explode, but adds to the same die's total; bare form compounds on the maximum face
 
 <success_modifier>  ::= <comparison_point>
 
-<failure_modifier>  ::= "f" <comparison_point> 
+<failure_modifier>  ::= "f" <comparison_point>
 
-<constant_modifier> ::= <arithmetic> <constant>
+<constant_modifier> ::= <arithmetic_op> <positive_integer>
 
-<comparison_point>  ::= <comparison_operator> <integer>
+<comparison_or_value> ::= <comparison_point>
+                        | <positive_integer> // bare integer means equality: "ro1" == "ro=1"
+
+<comparison_point>  ::= <comparison_operator> <positive_integer>
 
 <comparison_operator> ::= "=" | ">" | "<"
 
-<integer>           ::= ["-"] <digit>+
+<positive_integer>  ::= <digit>+ // must be > 0
 
 <digit>             ::= "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"


### PR DESCRIPTION
Fixes:
- Rerolls (ro/rc) in the simple Evaluate path rolled a die whose sides equaled the previous roll's result (e.g. 4d6ro=1 rerolled a 1 on a one-sided die). Rerolls now always use the original die.
- Combining success and failure counting (e.g. 6d10>8f<2) clobbered one another in both paths; it now returns successes minus failures counted against the same dice. Success takes precedence when criteria overlap.

Refactor:
- Evaluate() is now a projection of EvaluateDetailed().Value, deleting the parallel non-detailed modifier implementations (~400 lines) that had already diverged. BREAKING: keep/drop written before explode/ reroll/compound now follows the phase model (generate, keep/drop, finalize), matching ParseRollDetailed and common VTT behavior.

Grammar:
- Bare "!" and "^" explode/compound on the die's maximum face
- "!!" accepted as an alias for "^"
- Bare integer after ro/rc/!/^ means equality (ro1 == ro=1, 3d6!6 == 3d6!=6)

Also:
- Add configurable DiceEvaluator.MaxRerolls (default 10)
- Include Pidgin diagnostics in ParseRoll/ParseRollDetailed FormatException
- Add BugFixTests.cs: range-recording RNG regression tests, seeded differential tests (Evaluate == EvaluateDetailed), shorthand equivalence, success/failure combinations, MaxRerolls limits
- Update DiceParserTests for now-valid shorthands; align the "complex attack" evaluator test with phase-model semantics
- Correct README modifier docs (r/rr/cs/cf never existed; document ro/rc, >#, f>#, shorthands, evaluator settings), update grammar file, backfill CHANGELOG, bump version to 1.5.0